### PR TITLE
ability to define and load HTML fixtures in the suite.json file

### DIFF
--- a/django_qunit/templates/qunit/index.html
+++ b/django_qunit/templates/qunit/index.html
@@ -4,15 +4,6 @@
 	<title>QUnit Test Suite</title>
   <link rel="stylesheet" href="{% url qunit_css %}" type="text/css" media="screen">
   <script type="text/javascript" src="{% url qunit_js %}"></script>
-  {% for url in suite.extra_urls %}
-    <script type="text/javascript" src="{{ url }}"></script>
-  {% endfor %}
-  {% for url in suite.extra_media_urls %}
-    <script type="text/javascript" src="{{ MEDIA_URL }}{{ url }}"></script>
-  {% endfor %}
-  {% for file in files %}
-    <script type="text/javascript" src="{% url qunit_test file %}"></script>
-  {% endfor %}
 </head>
 <body>
   <h1 id="qunit-header">QUnit Test Suite ({{ suite.name|capfirst }})</h1>
@@ -31,5 +22,20 @@
   {% endif %}
 	<h2 id="qunit-userAgent"></h2>
 	<ol id="qunit-tests"></ol>
+        <div id="qunit-fixture">
+        {% for html in suite.html_fixtures %}
+          {{ html|safe }}
+        {% endfor %}
+        </div>
+
+  {% for url in suite.extra_urls %}
+    <script type="text/javascript" src="{{ url }}"></script>
+  {% endfor %}
+  {% for url in suite.extra_media_urls %}
+    <script type="text/javascript" src="{{ MEDIA_URL }}{{ url }}"></script>
+  {% endfor %}
+  {% for file in files %}
+    <script type="text/javascript" src="{% url qunit_test file %}"></script>
+  {% endfor %}
 </body>
 </html>

--- a/example/qunit_tests/example_fixture.html
+++ b/example/qunit_tests/example_fixture.html
@@ -1,0 +1,3 @@
+<div id="example-stub">
+<!-- just an example for inspiration -->
+</div>

--- a/example/qunit_tests/suite.json
+++ b/example/qunit_tests/suite.json
@@ -1,5 +1,8 @@
 {
     "name": "Main Test Suite",
+    "html_fixtures": [
+      "example_fixture.html"
+    ],
     "extra_urls": [
       "http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"
     ]


### PR DESCRIPTION
This fork adds the ability to specify templates that become embedded inside the `<div id="qunit-fixture">` tag. 
It also moves all Javascript extra modules to appear below the `qunit-fixture` DOM element. 

We're currently relying on this fork of mine for a project within Mozilla. Would be more than happy to discuss improving the fork with more documentation or tests. 
