### PR TITLE
Add support for CoffeeScript files

### DIFF
--- a/django_qunit/templates/qunit/index.html
+++ b/django_qunit/templates/qunit/index.html
@@ -10,6 +10,14 @@
   {% for url in suite.extra_media_urls %}
     <script type="text/javascript" src="{{ MEDIA_URL }}{{ url }}"></script>
   {% endfor %}
+  {% if compressor %}
+    {% for url in suite.coffeescript_urls %}
+      {% load compress %}
+      {% compress js %}
+        <script type="text/coffeescript" src="{{ url }}" />
+      {% endcompress %}
+    {% endfor %}
+  {% endif %}
   {% for file in files %}
     <script type="text/javascript" src="{% url qunit_test file %}"></script>
   {% endfor %}

--- a/django_qunit/views.py
+++ b/django_qunit/views.py
@@ -20,6 +20,7 @@ def get_suite_context(request, path):
     # defaults
     suite['extra_urls'] = []
     suite['extra_media_urls'] = []
+	suite['coffeescript_urls'] = []
 
     # load suite.json if present
     if 'suite.json' in files:
@@ -29,12 +30,17 @@ def get_suite_context(request, path):
 
     previous_directory = parent_directory(path)
 
+	compressor = False
+	if "compressor" in settings.INSTALLED_APPS:
+	    compressor = True
+
     return {
         'files': [path + file for file in files if file.endswith('js')],
         'previous_directory': previous_directory,
         'in_subdirectory': True and (previous_directory is not None) or False,
         'subsuites': directories,
         'suite': suite,
+		'compressor': compressor,
     }
 
 def run_tests(request, path):

--- a/django_qunit/views.py
+++ b/django_qunit/views.py
@@ -20,7 +20,7 @@ def get_suite_context(request, path):
     # defaults
     suite['extra_urls'] = []
     suite['extra_media_urls'] = []
-	suite['coffeescript_urls'] = []
+    suite['coffeescript_urls'] = []
 
     # load suite.json if present
     if 'suite.json' in files:
@@ -30,9 +30,9 @@ def get_suite_context(request, path):
 
     previous_directory = parent_directory(path)
 
-	compressor = False
-	if "compressor" in settings.INSTALLED_APPS:
-	    compressor = True
+    compressor = False
+    if "compressor" in settings.INSTALLED_APPS:
+        compressor = True
 
     return {
         'files': [path + file for file in files if file.endswith('js')],


### PR DESCRIPTION
Add the ability to include CoffeeScript files (.coffee) into the index page for testing. Will only work if django-compressor is installed and configured to precompile the .coffee files.

CoffeeScript is gaining popularity so I figured I would try it out. It's a very nice way to write JavaScript but you still have to compile it down to JS in order to unit test it with QUnit. Simply add a new set of path's in a new coffeescript_urls data set and they are automagically compressed and added to the index page.
